### PR TITLE
Implement case-insensitive search for string filters

### DIFF
--- a/src/components/Filters/StringFilter.js
+++ b/src/components/Filters/StringFilter.js
@@ -7,7 +7,7 @@ import { FilterHeader } from './common';
 import { filterStyles } from './filterStyles';
 
 function StringFilter({
-  capitalize = false,
+  caseSensitive = true,
   name,
   onChange,
   onRemove,
@@ -29,9 +29,9 @@ function StringFilter({
   };
 
   useUpdateEffect(() => {
-    const finalValue = capitalize
-      ? debouncedInputValue.toUpperCase()
-      : debouncedInputValue;
+    const finalValue = caseSensitive
+      ? debouncedInputValue
+      : RegExp(debouncedInputValue, 'i');
 
     onChange({ [name]: { $regex: finalValue } });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/Filters/filters.js
+++ b/src/components/Filters/filters.js
@@ -117,7 +117,7 @@ export const filters = (filterBy, onChange, onRemove) => ({
     <StringFilter
       name="invitro_covid_activity"
       value={getFilter(filterBy, 'invitro_covid_activity')}
-      capitalize
+      caseSensitive={false}
       onChange={onChange}
       onRemove={onRemove}
       title="In-vitro compound activity"


### PR DESCRIPTION
This PR replaces the `capitalize` parameter of the `StringFilter` component with the `caseSensitive` parameter, which by default is set to `false`. When `caseSensitive=false`, terms entered into the search box will not be modified and only perfect (case-sensitive) matches will be returned. When `caseSensitive=true`, a case-insensitive search is performed. You can see an example in the attached screenshot when applying this to the "invitro_covid_activity" column.

![Screenshot 2021-09-03 at 16 39 58](https://user-images.githubusercontent.com/18103560/132024866-b0d7e1a2-effe-4974-83c2-aec47034e4a5.png)

I hope you find this useful.