### PR TITLE
Add range filter for numeric columns

### DIFF
--- a/src/components/Filters/RangeFilter.js
+++ b/src/components/Filters/RangeFilter.js
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { Box, makeStyles, Paper, Typography } from '@material-ui/core';
+import Slider from '@material-ui/core/Slider';
+
+import useDebounce from '../../hooks/useDebounce';
+import useUpdateEffect from '../../hooks/useUpdateEffect';
+import { FilterHeader } from './common';
+import { filterStyles } from './filterStyles';
+
+function numberWithThousandSeparators(x) {
+  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+const useStyles = makeStyles((theme) => ({
+  slider: {
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    margin: 'auto',
+    marginTop: '0.5rem',
+    width: '80%',
+  },
+  text: {
+    color: theme.palette.grey[500],
+    fontSize: '0.85rem',
+    fontStyle: 'italic',
+    paddingBottom: '.5rem',
+    textAlign: 'center',
+  },
+}));
+
+function RangeFilter({
+  name,
+  altName,
+  onChange,
+  onRemove,
+  value,
+  min = 0,
+  max = 100,
+  ...headerProps
+}) {
+  const sliderClasses = useStyles();
+  const classes = filterStyles();
+
+  const [range, setRange] = useState([min, max]);
+  const debouncedRange = useDebounce(range, 1000);
+
+  const handleRemoveFilter = () => {
+    setRange([min, max]);
+    onRemove(altName || name);
+  };
+
+  useUpdateEffect(() => {
+    onChange({
+      [name]: { $gte: debouncedRange[0], $lte: debouncedRange[1] },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedRange]);
+
+  const handleChangeRange = (event, newRange) => {
+    setRange(newRange);
+  };
+
+  return (
+    <Paper className={classes.filterContainer}>
+      <FilterHeader onRemove={handleRemoveFilter} {...headerProps} />
+      <Box className={classes.filterBodyContainerRow}>
+        <Slider
+          className={sliderClasses.slider}
+          value={range}
+          min={min}
+          max={max}
+          onChange={handleChangeRange}
+          valueLabelDisplay="off"
+          aria-labelledby="range-slider"
+          // getAriaValueText={(value) => `${value} n`}
+        />
+      </Box>
+      <Box className={classes.filterBodyContainerRow}>
+        <Typography
+          className={sliderClasses.text}
+        >{`Range: ${numberWithThousandSeparators(
+          range[0]
+        )} - ${numberWithThousandSeparators(range[1])}`}</Typography>
+      </Box>
+    </Paper>
+  );
+}
+
+export default RangeFilter;

--- a/src/components/Filters/filters.js
+++ b/src/components/Filters/filters.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import IntegerFilter from './IntegerFilter';
 import MultiListFilter from './MultiListFilter';
+import RangeFilter from './IntegerFilter';
 import SafetySourceFilter from './SafetySourceFilter';
 import StringFilter from './StringFilter';
 import ToggleFilter from './ToggleFilter';
@@ -93,9 +93,11 @@ export const filters = (filterBy, onChange, onRemove) => ({
     />
   ),
   drugs_in_clinic: (
-    <IntegerFilter
+    <RangeFilter
       name="drugs_in_clinic"
       value={getFilter(filterBy, 'drugs_in_clinic')}
+      min={0}
+      max={67}
       onChange={onChange}
       onRemove={onRemove}
       title="Drugs in clinic"


### PR DESCRIPTION
This PR adds a range filter for numeric columns. This is useful because more is not always better in the context of numeric columns, which is currently the only way of filtering those (see `IntegerFilter`). The min and max values have to be set manually. Perhaps this could be done automatically by querying the PouchDB once.

You can see in the screenshot below how it looks when applied to the "drugs_in_clinic" column.

![Screenshot 2021-09-03 at 16 32 54](https://user-images.githubusercontent.com/18103560/132025456-356d1254-7a51-47d8-8c0d-929bd2ce3c3c.png)

Hopefully you find this useful.