### PR TITLE
Add option to use `CellArray` component without a link for each element

### DIFF
--- a/src/components/Cells/CellArray.js
+++ b/src/components/Cells/CellArray.js
@@ -27,7 +27,7 @@ export const CellArray = ({
       <List>
         {array.map((accession, i) => (
           <ListItem key={i}>
-            <CellLink {...link} accession={accession} />
+            {link ? <CellLink {...link} accession={accession} /> : accession}
           </ListItem>
         ))}
       </List>


### PR DESCRIPTION
This PR extends the already partially existing logic on not creating links for elements in `CellArray` when no `link` parameter was provided. So far, this only worked for arrays of length 1.

This is how it looks when temporarily removing the `link` parameter for the "Respiratory system tissues" column.

![Screenshot 2021-09-03 at 17 38 49](https://user-images.githubusercontent.com/18103560/132032118-4e1223cb-8d3c-4d88-ac52-aac60ee7bdc5.png)

I hope you find it useful.